### PR TITLE
Migrate from react-dnd  to react-beautiful-dnd

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,14 +99,11 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17",
-    "react-dnd": "^16.0.1",
-    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^16.8.0 || ^17"
   },
   "dependencies": {
     "prop-types": "^15.7.2",
-    "react-dnd": "^16.0.1",
-    "react-dnd-html5-backend": "^16.0.1",
+    "react-beautiful-dnd": "^13.1.1",
     "react-icons": "^4.1.0",
     "use-tree-state": "1.0.0"
   }

--- a/src/components/FolderTree/FolderTree.jsx
+++ b/src/components/FolderTree/FolderTree.jsx
@@ -1,5 +1,5 @@
-import React, { useRef, useState } from 'react';
-import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import React from 'react';
+import { DragDropContext } from 'react-beautiful-dnd';
 import PropTypes from 'prop-types';
 import useTreeState, {
   testData,
@@ -61,7 +61,6 @@ const FolderTree = ({
     debug,
     searchData,
     showSearchData,
-    dndConfig,
   };
 
   /* ----------

--- a/src/components/FolderTree/FolderTree.jsx
+++ b/src/components/FolderTree/FolderTree.jsx
@@ -1,8 +1,5 @@
-import React, {
-  useCallback, useMemo, useRef, useState,
-} from 'react';
-import { DndProvider } from 'react-dnd';
-import { HTML5Backend } from 'react-dnd-html5-backend';
+import React, { useRef, useState } from 'react';
+import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 import PropTypes from 'prop-types';
 import useTreeState, {
   testData,
@@ -44,13 +41,6 @@ const FolderTree = ({
   const { treeState, reducers } = useTreeState({ data, options, onChange });
   const { checkNode, renameNode, deleteNode, addNode, toggleOpen } = reducers;
 
-  const [dndArea, setDndArea] = useState(null);
-  const folderTreeRefCallback = useCallback(node => setDndArea(node), []);
-  const html5Options = useMemo(
-    () => ({ rootElement: dndArea }),
-    [dndArea],
-  );
-
   if (!treeState) return null;
 
   const configs = {
@@ -83,18 +73,43 @@ const FolderTree = ({
     console.log('tree state: ', treeState);
   }
 
+  const { onDrop, onDragStart } = dndConfig || {};
+
+  const handleDragEnd = result => {
+    if (!result.destination) {
+      return;
+    }
+
+    if (result.destination.index === result.source.index) {
+      return;
+    }
+
+    const dropTargetItem = {
+      folderID: result.destination.droppableId,
+    };
+    const dragItem = {
+      fileID: result.draggableId,
+    };
+    onDrop?.(dropTargetItem, dragItem);
+  };
+
+  const handleDragStart = result => {
+    const dragItem = {
+      fileID: result.draggableId,
+    };
+    onDragStart?.(dragItem);
+  };
+
   return (
-    <div ref={ folderTreeRefCallback } className='FolderTree'>
-      {dndArea == null ? null : (
-        <DndProvider
-          backend={ HTML5Backend }
-          options={ html5Options }
+    <div className='FolderTree'>
+      <ConfigContext.Provider value={ configs }>
+        <DragDropContext
+          onDragStart={ handleDragStart }
+          onDragEnd={ handleDragEnd }
         >
-          <ConfigContext.Provider value={configs}>
-            <TreeNode key={treeState._id} path={[]} {...treeState} />
-          </ConfigContext.Provider>
-        </DndProvider>
-      )}
+          <TreeNode key={ treeState._id } path={ [] } { ...treeState } />
+        </DragDropContext>
+      </ConfigContext.Provider>
     </div>
   );
 };

--- a/src/components/SandBox/SandBox.jsx
+++ b/src/components/SandBox/SandBox.jsx
@@ -1,87 +1,19 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import FolderTree, { testData } from '../FolderTree/FolderTree';
-
-const makeId = (length) => {
-  let result = '';
-  const characters =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  const charactersLength = characters.length;
-
-  for (let i = 0; i < length; i += 1) {
-    result += characters.charAt(Math.floor(Math.random() * charactersLength));
-  }
-
-  return result;
-};
-
-// 21 IDs, so that they are always the same - add if needed
-const testIDS = [
-  '1YX7vvp1oSsKbVmk',
-  'KEdX5ukj6cyqHhri',
-  'FCGk0rlxnozNwO7X',
-  'C7hdysACGIBQR0CC',
-  '3XPTvpd20DhLYg6j',
-  '4WIhn55ynVOGiHix',
-  'FwNTUcPZv0ET2adh',
-  'BaJ5vmxUKPNuca7V',
-  'wmAB3wqXmT7yx3Um',
-  'lerFQtc7usZlV0QI',
-  'GNLwtJCdXjFGo3R7',
-  'xgwySK2ABj3oQUng',
-  'Ga1zvj8qWOEfOVL2',
-  'YWm9BjSXt4PiCLMB',
-  '1Cxoe9DBs7oiEWps',
-  'rFSWgJu0d9Lgoso1',
-  'ufJsFqhGMYDmGHNO',
-  'FdLmoTCujAjM9VME',
-  'Q4SXolIgSodJJR9r',
-  '3PetnwWjtbJErDuk',
-  'SayEciikZbEGeiWy',
-];
-
-const parseTestData = (node) => {
-  let count = 0;
-
-  const parse = (node) => {
-    if (!node) return null;
-
-    count++;
-
-    if (node.children) {
-      node['folderID'] = testIDS[count];
-      node.children.forEach((item) => {
-        parse(item);
-      });
-    } else {
-      node['fileID'] = testIDS[count];
-    }
-
-    return node;
-  };
-
-  return parse(node, count);
-};
+import FolderTree from '../FolderTree/FolderTree';
+import { testData } from '../../utils/testData';
 
 /* eslint-disable */
 const SandBox = ({ dndConfig }) => {
   const onTreeStateChange = (state, e) => console.log({ state, e });
   const [tree, setTree] = useState(null);
 
-  console.log('test data', testData);
-
-  useEffect(() => {
-    const parsedData = parseTestData(testData, 1);
-    setTree(parsedData);
-    console.log('parsed data', parsedData);
-  }, []);
-
   return (
-    !!tree && (
+    !!testData && (
       <div className='demo-sandbox'>
         <FolderTree
           dndConfig={dndConfig}
-          data={tree}
+          data={testData}
           onChange={onTreeStateChange}
           onIconClick={(e, nodeData) => {
             console.log('INSIDE ICON CLICK', e, nodeData);

--- a/src/components/TreeNode/TreeNode.jsx
+++ b/src/components/TreeNode/TreeNode.jsx
@@ -1,11 +1,10 @@
 import React, {
   useContext,
   useEffect,
-  useRef,
   useState,
-  forwardRef
+  forwardRef,
 } from 'react';
-import { Droppable, Draggable } from "react-beautiful-dnd";
+import { Droppable, Draggable } from 'react-beautiful-dnd';
 import PropTypes from 'prop-types';
 import {
   AiFillCaretRight,
@@ -57,7 +56,6 @@ const TreeNodeChild = forwardRef(({
     onIconClick,
     showCheckbox,
     readOnly,
-    dndConfig,
 
     searchData,
     showSearchData,
@@ -87,8 +85,6 @@ const TreeNodeChild = forwardRef(({
     ...restData,
   };
 
-  const { onDrop, onDragStart } = dndConfig || {};
-
   const level = path.length;
 
   const offsetSize = !isFolder ? 0 : iconSize;
@@ -98,7 +94,6 @@ const TreeNodeChild = forwardRef(({
     marginLeft: level * indentPixels - offsetDiff,
   };
   
-
   if (debug) {
     console.log('----');
     console.log({
@@ -254,16 +249,15 @@ const TreeNodeChild = forwardRef(({
   // TreeNode__top: level === 1,
   // [`TreeNode__level-${level}`]: true,
 
-  const isDragging = snapshot.isDragging;
-  const isOver = snapshot.isDraggingOver;
+  const { isDragging, isDraggingOver: isOver } = snapshot;
   const { style, ...draggableProps } = provided.draggableProps || {};
-  const dndProps = isFolder ? {...provided.droppableProps} : {...draggableProps, ...provided.dragHandleProps};
+  const dndProps = isFolder ? { ...provided.droppableProps } : { ...draggableProps, ...provided.dragHandleProps };
   const dragStyle = isFolder ? null : provided.draggableProps?.style;
 
   return (
     <>
       <div
-        ref={ref}
+        ref={ ref }
         className={ `TreeNode ${
           isFolder ? 'TreeNode__folder' : 'TreeNode__file'
         } ${isSelected ? 'TreeNode__selected' : ''} ${
@@ -271,8 +265,8 @@ const TreeNodeChild = forwardRef(({
         } ${isDragging ? 'TreeNode__dragged' : ''} ${isOver ? 'TreeNode__dragged-over' : ''} ${isOpen ? 'TreeNode__open' : ''} ${
           level === 0 ? 'TreeNode__root' : ''
         } ${level === 1 ? 'TreeNode__top' : ''} TreeNode__level-${level}` }
-        style={ { ...treeNodeStyle, ...dragStyle } }
-        {...dndProps}
+        style={{ ...treeNodeStyle, ...dragStyle }}
+        { ...dndProps }
       >
         {showCheckbox && (
           <CheckBox status={checked} onChange={handleCheckBoxChange} />
@@ -307,10 +301,10 @@ const TreeNodeChild = forwardRef(({
         {isSelected && TreeNodeToolBar}
       </div>
 
-      {isFolder &&
-        isOpen &&
-        children.map((data, idx) => (
-          <TreeNode key={data._id} path={[...path, idx]} {...data} />
+      {isFolder
+        && isOpen
+        && children.map((data, idx) => (
+          <TreeNode key={ data._id } path={ [...path, idx] } { ...data } />
         ))}
       {isFolder && provided.placeholder}
     </>
@@ -325,39 +319,49 @@ TreeNodeChild.propTypes = {
   fileID: PropTypes.string,
   folderID: PropTypes.string,
   children: PropTypes.array,
+  snapshot: PropTypes.object,
+  provided: PropTypes.object,
 };
 
-let itemIndex = 0;
+let indexCounter = 0;
 
-const TreeNode = (props) => {
+const TreeNode = props => {
   const { folderID, fileID } = props;
   const isFolder = !!props.children;
   const [index, setIndex] = useState(0);
-  
+
   useEffect(() => {
-    itemIndex++;
-    setIndex(itemIndex);
+    indexCounter += 1;
+    setIndex(indexCounter);
   }, []);
 
-  if(index === 0) {
+  if (index === 0) {
     return null;
   }
 
   return isFolder ? (
-    <Droppable type='FolderNode' droppableId={folderID}>
+    <Droppable type='FolderNode' droppableId={ folderID }>
       {(provided, snapshot) => (
-        <TreeNodeChild ref={provided.innerRef} provided={provided} snapshot={snapshot} {...props} />
+        <TreeNodeChild ref={ provided.innerRef } provided={ provided } snapshot={ snapshot } { ...props } />
       )}
     </Droppable>
   ) : (
     <Draggable
-      draggableId={fileID}
-      index={index}
+      draggableId={ fileID }
+      index={ index }
     >
       {(provided, snapshot) => (
-        <TreeNodeChild ref={provided.innerRef} provided={provided} snapshot={snapshot} {...props} />
+        <TreeNodeChild ref={ provided.innerRef } provided={ provided } snapshot={ snapshot } { ...props } />
       )}
     </Draggable>
-  );     
-}
+  );
+};
+
+TreeNode.propTypes = {
+  isOpen: PropTypes.bool,
+  fileID: PropTypes.string,
+  folderID: PropTypes.string,
+  children: PropTypes.array,
+};
+
 export default TreeNode;

--- a/src/components/TreeNode/TreeNode.jsx
+++ b/src/components/TreeNode/TreeNode.jsx
@@ -252,7 +252,7 @@ const TreeNodeChild = forwardRef(({
   const { isDragging, isDraggingOver: isOver } = snapshot;
   const { style, ...draggableProps } = provided.draggableProps || {};
   const dndProps = isFolder ? { ...provided.droppableProps } : { ...draggableProps, ...provided.dragHandleProps };
-  const dragStyle = isFolder ? null : provided.draggableProps?.style;
+  const dragStyle = isDragging && !isFolder ? style : null;
 
   return (
     <>
@@ -299,6 +299,8 @@ const TreeNodeChild = forwardRef(({
           />
         </span>
         {isSelected && TreeNodeToolBar}
+        {/* Hide while also preventing dnd from complaining of missing provided.placeholder */}
+        {isFolder && <div id="droppable-placeholder" style={{display: 'none'}}>{provided.placeholder}</div>}
       </div>
 
       {isFolder
@@ -306,7 +308,6 @@ const TreeNodeChild = forwardRef(({
         && children.map((data, idx) => (
           <TreeNode key={ data._id } path={ [...path, idx] } { ...data } />
         ))}
-      {isFolder && provided.placeholder}
     </>
   );
 });

--- a/src/components/TreeNode/TreeNode.test.js
+++ b/src/components/TreeNode/TreeNode.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DragDropContext } from 'react-beautiful-dnd';
 import { mount } from 'enzyme';
 import TreeNode from './TreeNode';
 
@@ -42,21 +43,24 @@ const render = ({
     indentPixels,
     showCheckbox,
     readOnly,
-    dndConfig,
   };
 
   node = mount((
     <ConfigContext.Provider
       value={ configs }
     >
-      <TreeNode
-        path={ path }
-        name={ name }
-        checked={ checked }
-        isOpen={ isOpen }
-        children={ children }
-        { ...restData }
-      />
+      <DragDropContext
+        onDragEnd={ dndConfig.onDrop }
+      >
+        <TreeNode
+          path={ path }
+          name={ name }
+          checked={ checked }
+          isOpen={ isOpen }
+          children={ children }
+          { ...restData }
+        />
+      </DragDropContext>
     </ConfigContext.Provider>
   ));
 };

--- a/src/components/TreeNode/TreeNode.test.js
+++ b/src/components/TreeNode/TreeNode.test.js
@@ -28,7 +28,6 @@ const render = ({
   name,
   checked,
   isOpen,
-  children,
   ...restData
 }) => {
   const configs = {
@@ -57,7 +56,6 @@ const render = ({
           name={ name }
           checked={ checked }
           isOpen={ isOpen }
-          children={ children }
           { ...restData }
         />
       </DragDropContext>

--- a/src/test/jest-setup.js
+++ b/src/test/jest-setup.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React from 'react';
 import { configure } from 'enzyme';
 // import Adapter from 'enzyme-adapter-react-16';

--- a/src/test/jest-setup.js
+++ b/src/test/jest-setup.js
@@ -5,15 +5,13 @@ import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
 configure({ adapter: new Adapter() });
 
-// Mock implementation for the DndProvider component
-const DndProvider = ({ children }) => <div>{children}</div>;
+// Mock implementation for react-beautiful-dnd
 
-jest.mock('react-dnd', () => ({
-  useDrag: jest.fn((...args) => [{ isDragging: false }, jest.fn()]),
-  useDrop: jest.fn((...args) => [{ isOver: false }, jest.fn()]),
-  DndProvider,
-}));
-
-jest.mock('react-dnd-html5-backend', () => ({
-  HTML5Backend: jest.fn(),
+const DragDropContext = ({ children }) => <div>{children}</div>;
+const Draggable = ({ children }) => children({ draggableProps: {}, dragHandleProps: {}, innerRef: () => {} }, { isDragging: false });
+const Droppable = ({ children }) => children({ droppableProps: {}, placeholder: null }, { isDraggingOver: false });
+jest.mock('react-beautiful-dnd', () => ({
+  DragDropContext,
+  Droppable,
+  Draggable,
 }));

--- a/src/utils/dnd.js
+++ b/src/utils/dnd.js
@@ -1,3 +1,0 @@
-export const FileTreeDragTypes = {
-  TREE_NODE: 'TREE_NODE',
-};

--- a/src/utils/testData.js
+++ b/src/utils/testData.js
@@ -1,47 +1,98 @@
 const testData = {
   name: 'All Cryptos',
   children: [
-    { name: 'Bitcoin' },
-    { name: 'Etherium' },
-    { name: 'Polkadot' },
+    {
+      name: 'Bitcoin',
+      fileID: 'FCGk0rlxnozNwO7X',
+    },
+    {
+      name: 'Etherium',
+      fileID: 'C7hdysACGIBQR0CC',
+    },
+    {
+      name: 'Polkadot',
+      fileID: '3XPTvpd20DhLYg6j',
+    },
     {
       name: 'POW',
       children: [
-        { name: 'Bitcoin' },
-        { name: 'Litecoin' },
-        { name: 'Bitcoin Cash' },
+        {
+          name: 'Bitcoin',
+          fileID: 'FwNTUcPZv0ET2adh',
+        },
+        {
+          name: 'Litecoin',
+          fileID: 'BaJ5vmxUKPNuca7V',
+        },
+        {
+          name: 'Bitcoin Cash',
+          fileID: 'wmAB3wqXmT7yx3Um',
+        },
       ],
+      folderID: '4WIhn55ynVOGiHix',
     },
     {
       name: 'Public Chains',
       children: [
-        { name: 'Ripple' },
-        { name: 'Chainlink' },
+        {
+          name: 'Ripple',
+          fileID: 'GNLwtJCdXjFGo3R7',
+        },
+        {
+          name: 'Chainlink',
+          fileID: 'xgwySK2ABj3oQUng',
+        },
         {
           name: 'POW',
           children: [
-            { name: 'Bitcoin' },
-            { name: 'Litecoin' },
-            { name: 'Bitcoin Cash' },
+            {
+              name: 'Bitcoin',
+              fileID: 'YWm9BjSXt4PiCLMB',
+            },
+            {
+              name: 'Litecoin',
+              fileID: '1Cxoe9DBs7oiEWps',
+            },
+            {
+              name: 'Bitcoin Cash',
+              fileID: 'rFSWgJu0d9Lgoso1',
+            },
           ],
+          folderID: 'Ga1zvj8qWOEfOVL2',
         },
         {
           name: 'POS',
           children: [
-            { name: 'Etherium' },
-            { name: 'EOS' },
+            {
+              name: 'Etherium',
+              fileID: 'FdLmoTCujAjM9VME',
+            },
+            {
+              name: 'EOS',
+              fileID: 'Q4SXolIgSodJJR9r',
+            },
             {
               name: 'Crosschain',
               children: [
-                { name: 'Polkadot' },
-                { name: 'Cosmos' },
+                {
+                  name: 'Polkadot',
+                  fileID: 'SayEciikZbEGeiWy',
+                },
+                {
+                  name: 'Cosmos',
+                  fileID: '1YX7vvp1oSikZbEG',
+                },
               ],
+              folderID: '3PetnwWjtbJErDuk',
             },
           ],
+          folderID: 'ufJsFqhGMYDmGHNO',
         },
       ],
+      folderID: 'lerFQtc7usZlV0QI',
     },
   ],
+  folderID: 'KEdX5ukj6cyqHhri',
 };
 
 const testDataWithId = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,6 +910,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.15.4":
+  version "7.22.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
+  integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/runtime@^7.9.2":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
@@ -1159,21 +1166,6 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.15.tgz#6a9d143f7f4f49db2d782f9e1c8839a29b43ae23"
   integrity sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA==
 
-"@react-dnd/asap@^5.0.1":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-5.0.2.tgz#1f81f124c1cd6f39511c11a881cfb0f715343488"
-  integrity sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==
-
-"@react-dnd/invariant@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@react-dnd/invariant/-/invariant-4.0.2.tgz#b92edffca10a26466643349fac7cdfb8799769df"
-  integrity sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==
-
-"@react-dnd/shallowequal@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz#d1b4befa423f692fa4abf1c79209702e7d8ae4b4"
-  integrity sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==
-
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -1267,6 +1259,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
@@ -1325,6 +1325,35 @@
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"
   integrity sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
+
+"@types/prop-types@*":
+  version "15.7.5"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
+  integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+
+"@types/react-redux@^7.1.20":
+  version "7.1.25"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.25.tgz#de841631205b24f9dfb4967dd4a7901e048f9a88"
+  integrity sha512-bAGh4e+w5D8dajd6InASVIyCo4pZLJ66oLb80F9OBLO1gKESbZcRCJpTT6uLXX+HAB57zw1WTdwJdAsewuTweg==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
+
+"@types/react@*":
+  version "18.2.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.14.tgz#fa7a6fecf1ce35ca94e74874f70c56ce88f7a127"
+  integrity sha512-A0zjq+QN/O0Kpe30hA1GidzyFjatVvrpIvWLxD+xv67Vt91TWWgco9IvrJBkeyHm1trGaFS/FSGqPlhyeZRm0g==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.3"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.3.tgz#cef09e3ec9af1d63d2a6cc5b383a737e24e6dcf5"
+  integrity sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -2688,6 +2717,13 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-box-model@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
+  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
+  dependencies:
+    tiny-invariant "^1.0.6"
+
 css-loader@^5.0.1:
   version "5.2.6"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-5.2.6.tgz#c3c82ab77fea1f360e587d871a6811f4450cc8d1"
@@ -2741,6 +2777,11 @@ cssstyle@^2.3.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
+
+csstype@^3.0.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
+  integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -2922,15 +2963,6 @@ discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
   integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
-
-dnd-core@^16.0.1:
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-16.0.1.tgz#a1c213ed08961f6bd1959a28bb76f1a868360d19"
-  integrity sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==
-  dependencies:
-    "@react-dnd/asap" "^5.0.1"
-    "@react-dnd/invariant" "^4.0.1"
-    redux "^4.2.0"
 
 dns-equal@^1.0.0:
   version "1.0.0"
@@ -3655,7 +3687,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -4171,7 +4203,7 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -5713,6 +5745,11 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
+memoize-one@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 memory-fs@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -6798,6 +6835,11 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
   integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
+raf-schd@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
+  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
+
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -6840,23 +6882,18 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-dnd-html5-backend@^16.0.1:
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz#87faef15845d512a23b3c08d29ecfd34871688b6"
-  integrity sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==
+react-beautiful-dnd@^13.1.1:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz#b0f3087a5840920abf8bb2325f1ffa46d8c4d0a2"
+  integrity sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==
   dependencies:
-    dnd-core "^16.0.1"
-
-react-dnd@^16.0.1:
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-16.0.1.tgz#2442a3ec67892c60d40a1559eef45498ba26fa37"
-  integrity sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==
-  dependencies:
-    "@react-dnd/invariant" "^4.0.1"
-    "@react-dnd/shallowequal" "^4.0.1"
-    dnd-core "^16.0.1"
-    fast-deep-equal "^3.1.3"
-    hoist-non-react-statics "^3.3.2"
+    "@babel/runtime" "^7.9.2"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.2.0"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
 
 "react-dom@^16.8.0 || ^17":
   version "17.0.2"
@@ -6881,6 +6918,18 @@ react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-redux@^7.2.0:
+  version "7.2.9"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.9.tgz#09488fbb9416a4efe3735b7235055442b042481d"
+  integrity sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
 
 react-shallow-renderer@^16.13.1:
   version "16.14.1"
@@ -7017,7 +7066,7 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-redux@^4.2.0:
+redux@^4.0.0, redux@^4.0.4:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
   integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
@@ -8166,6 +8215,11 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+tiny-invariant@^1.0.6:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
+  integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -8435,6 +8489,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-memo-one@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
+  integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
 
 use-tree-state@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR migrates from `react-dnd` to `react-beautiful-dnd` due to unnecessary conflicts caused by `react-dnd ` in parent project when `react-dnd` is also used. 